### PR TITLE
Travis CI: Add Python 3.7 and flake8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      install: pip install flake8  # until requirements.txt is ready for Python 3.7
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ python:
   - "3.6"
 
 matrix:
+  allow_failures:
+    - python: 3.7
   include:
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
@@ -19,6 +21,7 @@ matrix:
 install:
   - pip install -r requirements.txt
   - pip install .[rmq]
+  - pip install flake8
 
 before_script:
   # stop the build if there are Python syntax errors or undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,21 @@ python:
   - "3.5"
   - "3.6"
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+
 install:
   - pip install -r requirements.txt
   - pip install .[rmq]
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 script:
   - py.test

--- a/examples/rmq_rpc_client.py
+++ b/examples/rmq_rpc_client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from kiwipy import rmq
 
-communicator = rmq.RmqCommunicator.connect(connection_params={url: 'amqp://localhost'})
+communicator = rmq.RmqCommunicator.connect(connection_params={'url': 'amqp://localhost'})
 
 # Send an RPC message
 print(" [x] Requesting fib(30)")


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree