### PR TITLE
Cleanup exchanges and queues in testing mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-# yet another python formatter
 # modernizer: make sure our code-base is Python 3 ready
 - repo: https://github.com/python-modernize/python-modernize.git
   sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
@@ -9,6 +8,7 @@
       - --write
       - --nobackups
 
+# yet another python formatter
 - repo: local
   hooks:
   # yapf = yet another python formatter
@@ -18,7 +18,7 @@
     language: system
     types: [python]
     args: ["-i"]
-    exclude: &exclude_files >
+    exclude: &exclude_files >-
       (?x)^(
         ^docs/|
       )$

--- a/kiwipy/rmq/communicator.py
+++ b/kiwipy/rmq/communicator.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from concurrent.futures import Future as ThreadFuture
 from functools import partial
+import copy
 import logging
 import threading
 
@@ -64,7 +65,8 @@ class RmqSubscriber(object):
                  connection,
                  message_exchange=defaults.MESSAGE_EXCHANGE,
                  decoder=defaults.DECODER,
-                 encoder=defaults.ENCODER):
+                 encoder=defaults.ENCODER,
+                 testing_mode=False):
         """
         Subscribes and listens for process control messages and acts on them
         by calling the corresponding methods of the process manager.
@@ -81,6 +83,7 @@ class RmqSubscriber(object):
         self._exchange = None
         self._exchange_name = message_exchange
         self._decode = decoder
+        self._testing_mode = testing_mode
         self._response_encode = encoder
 
         self._rpc_subscribers = {}
@@ -112,8 +115,13 @@ class RmqSubscriber(object):
             # Already connected
             return
 
+        exchange_params = copy.copy(EXCHANGE_PROPERTIES)
+
+        if self._testing_mode:
+            exchange_params.setdefault('auto_delete', self._testing_mode)
+
         self._channel = yield self._connection.channel()
-        self._exchange = yield self._channel.declare_exchange(name=self._exchange_name, **EXCHANGE_PROPERTIES)
+        self._exchange = yield self._channel.declare_exchange(name=self._exchange_name, **exchange_params)
 
         # RPC queue
         rpc_queue = yield self._channel.declare_queue(
@@ -261,12 +269,13 @@ class RmqCommunicator(object):
         self._connected = False
 
         self._message_subscriber = RmqSubscriber(
-            connection, message_exchange=message_exchange, encoder=encoder, decoder=decoder)
+            connection, message_exchange=message_exchange, encoder=encoder, decoder=decoder, testing_mode=testing_mode)
         self._message_publisher = RmqPublisher(
             connection,
             exchange_name=message_exchange,
             encoder=encoder,
             decoder=decoder,
+            testing_mode=testing_mode
         )
         self._task_subscriber = tasks.RmqTaskSubscriber(
             connection,

--- a/kiwipy/rmq/communicator.py
+++ b/kiwipy/rmq/communicator.py
@@ -271,12 +271,7 @@ class RmqCommunicator(object):
         self._message_subscriber = RmqSubscriber(
             connection, message_exchange=message_exchange, encoder=encoder, decoder=decoder, testing_mode=testing_mode)
         self._message_publisher = RmqPublisher(
-            connection,
-            exchange_name=message_exchange,
-            encoder=encoder,
-            decoder=decoder,
-            testing_mode=testing_mode
-        )
+            connection, exchange_name=message_exchange, encoder=encoder, decoder=decoder, testing_mode=testing_mode)
         self._task_subscriber = tasks.RmqTaskSubscriber(
             connection,
             exchange_name=task_exchange,

--- a/kiwipy/rmq/tasks.py
+++ b/kiwipy/rmq/tasks.py
@@ -47,7 +47,7 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
         :param encoder: A response encoder
         """
         super(RmqTaskSubscriber, self).__init__(
-            connection, exchange_name=exchange_name, exchange_params=exchange_params)
+            connection, exchange_name=exchange_name, exchange_params=exchange_params, testing_mode=testing_mode)
 
         self._task_queue_name = queue_name
         self._testing_mode = testing_mode


### PR DESCRIPTION
The `testing_mode` argument was not being propagated correctly to
all the entities declaring exchanges.