### PR TITLE
Log exception if call of task subscriber excepts for `no_reply=True`

### DIFF
--- a/kiwipy/rmq/tasks.py
+++ b/kiwipy/rmq/tasks.py
@@ -134,9 +134,13 @@ class RmqTaskSubscriber(messages.BaseConnectionWithExchange):
                 except KeyboardInterrupt:  # pylint: disable=try-except-raise
                     raise
                 except Exception as exc:  # pylint: disable=broad-except
-                    _LOGGER.debug('There was an exception in task %s:\n%s', exc, traceback.format_exc())
-                    if not task_body.no_reply:
+                    if task_body.no_reply:
+                        # The user has asked for no reply so log an error so they see this exception
+                        _LOGGER.exception('The task excepted')
+                    else:
+                        # Send the exception back to the other side but log here at INFO level also
                         reply_body = utils.exception_response(sys.exc_info()[1:])
+                        _LOGGER.info('There was an exception in a task %s:\n%s', exc, traceback.format_exc())
                     handled = True  # Finished
                 else:
                     # Create a reply message


### PR DESCRIPTION
If the call of a task subscriber excepts in `on_task` and
`no_reply=True`, the caller will never be made aware of this unless it
is explicitly logged as an exception. Since the caller specified to not
want a reply, the exception cannot be communicated through the response.